### PR TITLE
fix bug: strings (chars) get split on &quot;

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,8 @@ const parseResponse = (responseXml, cb) => {
     let res;
     let parent;
     let currentKey;
+    let oldKey;
+    let currentKeyStringParts;
 
     p.onEndDocument(() => {
 
@@ -233,6 +235,17 @@ const parseResponse = (responseXml, cb) => {
           }
 
           res[currentKey] = chars;
+          if (typeof chars === 'string'){
+              if(oldKey !== currentKey) {
+                  oldKey = currentKey;
+                  currentKeyStringParts = "";
+                  res[currentKey] = currentKeyStringParts;
+              }
+              if(oldKey === currentKey) {
+                  currentKeyStringParts += chars;
+                  res[currentKey] = currentKeyStringParts;
+              }
+          }
         }
       }
     });


### PR DESCRIPTION
When there is &quot; in the string the xml parser splits the string into different parts. This makes the opensrs package bug as well when returning "response_text" property. For example when the "response_text" is 'DNS Zone could not be set for qpwoeip18301.com. (Record type "" is not valid or supported.)' it returns only ' is not valid or supported.)' which is a problem for me since I'd like to show errors from the OpenSRS API directly to clients. (Too lazy to think of proper errors messages myself). On the other hand I was not too lazy to fix the code (which only took like 2 hours to figure out.. so here you go. Hope it gets into the repo. Or if you know of a cleverer way to do it - please tell me so I fix my code.